### PR TITLE
Add composite action + publish job

### DIFF
--- a/.github/actions/setup-libraries/action.yml
+++ b/.github/actions/setup-libraries/action.yml
@@ -1,0 +1,37 @@
+name: Setup Libraries
+description: Runs autogen.sh in required folders
+inputs:
+  libass-cmake-path:
+    description: Path of libass-cmake repos
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Install dependencies
+      run: sudo apt install gperf gettext autopoint
+      shell: bash
+
+    - name: Running autogen.sh in unibreak
+      working-directory: ${{ inputs.libass-cmake-path }}/src/unibreak
+      run: NOCONFIGURE=1 ./autogen.sh
+      shell: bash
+
+    - name: Running autogen.sh in fribidi
+      working-directory: ${{ inputs.libass-cmake-path }}/src/fribidi
+      run: NOCONFIGURE=1 ./autogen.sh
+      shell: bash
+
+    - name: Running autogen.sh in fontconfig
+      working-directory: ${{ inputs.libass-cmake-path }}/src/fontconfig
+      run: NOCONFIGURE=1 ./autogen.sh
+      shell: bash
+
+    - name: Running autogen.sh in ass
+      working-directory: ${{ inputs.libass-cmake-path }}/src/ass
+      run: ./autogen.sh
+      shell: bash
+
+    - name: Running buildconf.sh in expat
+      working-directory: ${{ inputs.libass-cmake-path }}/src/expat/expat
+      run: ./buildconf.sh
+      shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Publish Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  call-run-tests:
+    uses: ./.github/workflows/run_tests.yml
+
+  publish-release:
+    name: Publish Release
+    runs-on: ubuntu-latest
+    needs: call-run-tests
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+    - name: Download artifact
+      uses: actions/download-artifact@v6
+      with:
+        path: artifacts
+
+    - name: Create tarballs for each artifact
+      run: |
+        mkdir -p dist
+        for dir in artifacts/*; do
+          if [ -d "$dir" ]; then
+            name=$(basename "$dir")
+            tar_path="dist/${name}.tar.gz"
+            echo "Creating tarball $tar_path"
+            tar -czf "$tar_path" -C "$dir" .
+          fi
+        done
+
+    - name: Upload artifact signatures to GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: gh release upload '${{ github.ref_name }}' dist/*.tar.gz --repo '${{ github.repository }}'

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   pull_request:
+  workflow_call:
 
 jobs:
   run-tests:
@@ -21,28 +22,10 @@ jobs:
       with:
         submodules: true
 
-    - name: Install dependencies
-      run: sudo apt install gperf gettext autopoint
-  
-    - name: Running autogen.sh in unibreak
-      working-directory: src/unibreak
-      run: NOCONFIGURE=1 ./autogen.sh
-
-    - name: Running autogen.sh in fribidi
-      working-directory: src/fribidi
-      run: NOCONFIGURE=1 ./autogen.sh
-
-    - name: Running autogen.sh in fontconfig
-      working-directory: src/fontconfig
-      run: NOCONFIGURE=1 ./autogen.sh
-
-    - name: Running autogen.sh in ass
-      working-directory: src/ass
-      run: ./autogen.sh
-
-    - name: Running buildconf.sh in expat
-      working-directory: src/expat/expat
-      run: ./buildconf.sh
+    - name: Run setup-libraries composite action
+      uses: ./.github/actions/setup-libraries
+      with:
+        libass-cmake-path: ${{ github.workspace }}
 
     - name: Create build directory
       run: mkdir build
@@ -61,3 +44,12 @@ jobs:
     - name: Build
       working-directory: build
       run: cmake --build .
+
+    - uses: actions/upload-artifact@v5
+      with:
+        name: build-${{ matrix.ANDROID_ABI }}
+        path: |
+          build/etc/
+          build/include/
+          build/lib/
+          build/share/


### PR DESCRIPTION
In the first, I moved a part of the code in `run_tests.yml` which run the `autogen.sh` of all the dependencies. With this, we will be able to call it from the libass-android repos so we won't need to duplicate that code.

In the second commit, I added a job that is been run when you create a release on the web ui.
I created a release to show you how it look when the pipeline is been run: https://github.com/moi15moi/libass-cmake/releases/tag/0.1

This PR is what I wanted to do first in https://github.com/peerless2012/libass-cmake/pull/1, but it got merge a bit to fast.